### PR TITLE
[28기 박준영] 항공권 리스트 페이지 로딩 페이지 추가 구현

### DIFF
--- a/src/components/FlightInfoCard/FlightInfoCard.js
+++ b/src/components/FlightInfoCard/FlightInfoCard.js
@@ -1,7 +1,5 @@
 import styled from 'styled-components';
-import { CgArrowLongRight } from 'react-icons/cg';
-import { getParsedTime, getFlightTime } from '../../utils/getTime';
-
+import FlightTimeInfo from './FlightTimeInfo';
 const FlightInfoCard = ({
   flightInfo,
   selectThisFlight,
@@ -9,19 +7,6 @@ const FlightInfoCard = ({
   selected,
   children,
 }) => {
-  const {
-    id,
-    logo,
-    airline,
-    aircraft,
-    isDiscount,
-    tickets,
-    price,
-    baggage,
-    arrival,
-    departure,
-  } = flightInfo;
-
   const updateQSWithThisFlight = flightID => {
     selected ? reselectFlight(flightID) : selectThisFlight(flightID);
   };
@@ -30,35 +15,24 @@ const FlightInfoCard = ({
     <Container selected={selected}>
       {children}
       <FlightLogo>
-        <FlightLogoImg src={logo} alt={logo} />
+        <FlightLogoImg src={flightInfo.logo} alt={flightInfo.logo} />
         <FlexCol>
-          <h2>{airline}</h2>
-          <h3>{aircraft}</h3>
+          <h2>{flightInfo.airline}</h2>
+          <h3>{flightInfo.aircraft}</h3>
         </FlexCol>
       </FlightLogo>
 
-      <FlightInfo>
-        <Flex>
-          <span>{getParsedTime(departure.time)}</span>
-          <CgArrowLongRight size={30} />
-          <span>{getParsedTime(arrival.time)}</span>
-        </Flex>
-        <Flex>
-          <Typography color="gray_500">{departure.code}</Typography>
-          <Typography color="gray_500">
-            {getFlightTime(departure.time, arrival.time)}
-          </Typography>
-          <Typography color="gray_500">{arrival.code}</Typography>
-        </Flex>
-      </FlightInfo>
-
-      <Typography>{isDiscount ? '할인석' : '일반석'}</Typography>
-      <Typography>{tickets}석</Typography>
-      <FlightPriceInfo>{price.toLocaleString()}원</FlightPriceInfo>
-      {baggage ? (
-        `무료 수하물 ${baggage}kg`
+      <FlightTimeInfo flightInfo={flightInfo} />
+      <Typography>{flightInfo.isDiscount ? '할인석' : '일반석'}</Typography>
+      <Typography>{flightInfo.tickets}석</Typography>
+      <FlightPriceInfo>{flightInfo.price.toLocaleString()}원</FlightPriceInfo>
+      {flightInfo.baggage ? (
+        `무료 수하물 ${flightInfo.baggage ?? 15}kg`
       ) : (
-        <Button selected={selected} onClick={() => updateQSWithThisFlight(id)}>
+        <Button
+          selected={selected}
+          onClick={() => updateQSWithThisFlight(flightInfo.id)}
+        >
           {selected ? '항공권 변경' : '선택'}
         </Button>
       )}
@@ -104,17 +78,6 @@ const FlightLogoImg = styled.img`
   max-width: 2.5rem;
 `;
 
-const FlightInfo = styled.section`
-  display: grid;
-  place-items: center;
-
-  svg {
-    margin-inline: 0.5em;
-    color: ${({ theme }) => theme.color.gray_500};
-    transform: scale(1.5, 0.5);
-  }
-`;
-
 const Typography = styled.span`
   color: ${({ theme, color }) => (color ? theme.color[color] : 'inherit')};
   font-size: 0.875rem;
@@ -138,11 +101,6 @@ const Button = styled.button`
 
 const FlightPriceInfo = styled.h2`
   font-size: 1em;
-`;
-
-const Flex = styled.div`
-  ${({ theme }) => theme.flex};
-  gap: 0.5rem;
 `;
 
 const FlexCol = styled.div`

--- a/src/components/ReservedFlightTable/ReservedFlightTable.js
+++ b/src/components/ReservedFlightTable/ReservedFlightTable.js
@@ -6,7 +6,6 @@ import { getKORFormattedDate } from '../../utils/getTime';
 const ReservedFlightTable = ({ reservedFlightInfo }) => {
   return (
     <Container>
-      {console.log(reservedFlightInfo)}
       {reservedFlightInfo?.map((flightInfo, idx) => (
         <div key={idx}>
           <FlightBadge flightInfo={flightInfo} flightType={idx} size="lg">
@@ -40,6 +39,10 @@ const ResveredFlight = styled.div`
   justify-content: space-around;
   padding: 0.5em;
   border-block: 1px solid ${({ theme }) => theme.color.gray_500};
+
+  img {
+    max-width: 4rem;
+  }
 `;
 
 const FlexCol = styled.div`

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -8,4 +8,11 @@ export const GET_CHEAP_FLIGHTS_API = `http://10.58.2.221:8000/flights/main`;
 export const GET_SELECT_CITIES_API = `${BASE_URL}/data/flightsSearchBar/flightsSearchBar.json`;
 
 export const POST_PERSONALINFORMATION_API = `${BASE_URL}/orders`;
+// 항공권 리스트 페이지 API주소
+export const GET_ALL_FLIGHTS_INFO_API = `${BASE_URL}/data/flights/flightData.json`;
+export const GET_AIRLINE_OPTIONS_API = `${BASE_URL}/data/flights/airlineOption.json`;
+export const GET_SEAT_OPTIONS_API = `${BASE_URL}/data/flights/seatOption.json`;
+
+// 항공권
+
 // 예약 및 결제시에 사용되는 유효성 검사 이곳에 작성 해주세요.

--- a/src/hooks/useQueryString.js
+++ b/src/hooks/useQueryString.js
@@ -5,23 +5,26 @@ import {
 } from 'react-router-dom';
 
 const BASE_FLIGHT_QUERY = [
-  'departure_date',
-  'arrival_date',
-  'departure_city',
-  'arrival_city',
-  'adult',
-  'infant',
-  'child',
-  'at_time',
-  'airline_list',
-  'seat_type',
-  'maxprice',
-  'sort',
-  'is_round',
-  'departure_flight',
-  'return_flight',
+  'departure_date=',
+  'arrival_date=',
+  'departure_city=서울',
+  'arrival_city=',
+  'departure_city_code=SEL',
+  'arrival_city_code=',
+  'adult=1',
+  'infant=',
+  'child=',
+  'at_time=',
+  'airline_list=',
+  'seat_type=',
+  'maxprice=',
+  'sort=',
+  'is_round=YES',
+  'departure_flight=',
+  'return_flight=',
+  'imgLoading=YES',
 ];
-const INIT_QUERY_STRING = BASE_FLIGHT_QUERY.join('=&');
+const INIT_QUERY_STRING = BASE_FLIGHT_QUERY.join('&');
 
 const useQueryString = () => {
   const [searchParams, setSearchParams] = useSearchParams(INIT_QUERY_STRING);
@@ -99,11 +102,21 @@ const useQueryString = () => {
     navigate(`${pathname}?${searchParams}`);
   }
 
+  function getFilteredParams(userRequestKeys) {
+    const entries = [...searchParams.entries()];
+    const filteredEntries = entries.filter(([reqQueryKey, _]) =>
+      userRequestKeys.includes(reqQueryKey)
+    );
+    const filteredObj = Object.fromEntries(filteredEntries);
+    return filteredObj;
+  }
+
   return {
     searchParams,
     toggleQueryString,
     reflectUserSelectQueries,
     navigateToWithQueryString,
+    getFilteredParams,
   };
 };
 

--- a/src/pages/FlightsList/FlightsList.js
+++ b/src/pages/FlightsList/FlightsList.js
@@ -4,6 +4,7 @@ import FlightBadge from '../../components/FlightInfoCard/FlightBadge';
 import FlightFilter from './components/FlightFilter';
 import FlightPriceRange from './components/FlightPriceRange';
 import FlightInfoCard from '../../components/FlightInfoCard/FlightInfoCard';
+import FlightLoading from './components/FlightLoading';
 import useFetch from '../../hooks/useFetch';
 import useQueryString from '../../hooks/useQueryString';
 
@@ -13,6 +14,7 @@ const FlightsList = () => {
     reflectUserSelectQueries,
     toggleQueryString,
     navigateToWithQueryString,
+    getFilteredParams,
   } = useQueryString();
 
   const {
@@ -109,8 +111,21 @@ const FlightsList = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [searchParams]);
 
-  if (flightLoading || airlineLoading || seatLoading)
-    return <h1>Loading...</h1>;
+  const isDataYetFetched = flightLoading || airlineLoading || seatLoading;
+  const isImgLoading = searchParams.get('imgLoading') === 'YES';
+
+  const fadeOutImgLoading = () => {
+    reflectUserSelectQueries({ imgLoading: 'NO' });
+  };
+
+  if (isImgLoading)
+    return (
+      <FlightLoading
+        getFilteredParams={getFilteredParams}
+        fadeOutImgLoading={fadeOutImgLoading}
+      />
+    );
+  else if (isDataYetFetched) return <h1>Loading...</h1>;
   else if (flightError || airlineError || seatError) return <h2>Error</h2>;
   return (
     <Container>
@@ -176,12 +191,13 @@ const FlightsList = () => {
 export default FlightsList;
 
 const Container = styled.main`
+  position: relative;
   display: grid;
   grid-template-columns: 18rem auto;
   grid-template-rows: max-content auto;
   gap: 1.5rem;
   min-height: 150vh;
-  padding: 1rem 13vw;
+  padding: 4rem 13vw 1rem;
   background-color: ${({ theme }) => theme.color.gray_100};
   overflow: hidden;
 `;

--- a/src/pages/FlightsList/components/FlightLoading.js
+++ b/src/pages/FlightsList/components/FlightLoading.js
@@ -1,0 +1,155 @@
+import styled, { keyframes } from 'styled-components';
+const IMAGES = Array(100).fill(0);
+const INIT_QUERY_KEYS = [
+  'departure_date',
+  'arrival_date',
+  'departure_city',
+  'arrival_city',
+  'departure_city_code',
+  'arrival_city_code',
+];
+
+const FlightLoading = ({ getFilteredParams, fadeOutImgLoading }) => {
+  const destructedParams = getFilteredParams(INIT_QUERY_KEYS);
+
+  function preventAnimationEndBubble(e) {
+    e.stopPropagation();
+  }
+
+  return (
+    <Container onAnimationEnd={fadeOutImgLoading}>
+      <FlightInfoBox onAnimationEnd={preventAnimationEndBubble}>
+        <Title>
+          제주에서 여수까지
+          <br />
+          왕복 항공권을 찾고 있습니다.
+        </Title>
+        <FlightsBox>
+          <FlexCol>
+            <TypoGraphy size="lg">
+              {destructedParams.departure_city_code}
+            </TypoGraphy>
+            <TypoGraphy>{destructedParams.departure_city}</TypoGraphy>
+            <TypoGraphy>{destructedParams.departure_date}</TypoGraphy>
+          </FlexCol>
+          <FlexCol>
+            <TypoGraphy size="lg">
+              {destructedParams.arrival_city_code}
+            </TypoGraphy>
+            <TypoGraphy>{destructedParams.arrival_city}</TypoGraphy>
+            <TypoGraphy>{destructedParams.arrival_date}</TypoGraphy>
+          </FlexCol>
+        </FlightsBox>
+        <p>마이코드트립 항공권 구매자를 위한</p>
+        <TypoGraphy>랜터카 특별 혜택! 진짜 최저가로 예약하세요</TypoGraphy>
+      </FlightInfoBox>
+      <ImgBox onAnimationEnd={preventAnimationEndBubble}>
+        {IMAGES.map((_, idx) => (
+          <CellLoadingImg key={idx} x={idx % 10} y={Math.floor(idx / 10)} />
+        ))}
+      </ImgBox>
+    </Container>
+  );
+};
+
+export default FlightLoading;
+
+const contentFadeOut = keyframes`
+  99%{ 
+    opacity: 1;
+  }
+  100% { 
+    z-index: -1;
+    opacity: 0;
+  }
+`;
+
+const Container = styled.section`
+  --content-fadeout-delay: 3s;
+  --component-fadeout-delay: 7s;
+
+  position: absolute;
+  inset: 0;
+  height: 100vh;
+  z-index: 10;
+  overflow: hidden;
+  text-align: center;
+  color: ${({ theme }) => theme.color.white};
+  animation: ${contentFadeOut} forwards;
+  animation-delay: var(--component-fadeout-delay);
+
+  &::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background-color: rgba(0, 0, 0, 0.3);
+    animation: ${contentFadeOut} forwards;
+  }
+`;
+
+const FlightInfoBox = styled.div`
+  position: absolute;
+  inset: 10% 30%;
+  z-index: 10;
+  animation: ${contentFadeOut} forwards;
+  animation-delay: var(--content-fadeout-delay);
+`;
+
+const Title = styled.h2``;
+
+const FlightsBox = styled.div`
+  ${({ theme }) => theme.flex}
+  justify-content: space-around;
+  margin: 0.75em;
+  padding-block: 1.25em;
+  border-block: 1px solid ${({ theme }) => theme.color.gray_500};
+`;
+
+const FlexCol = styled.div`
+  ${({ theme }) => theme.columnFlex};
+  text-align: center;
+`;
+
+const TypoGraphy = styled.p`
+  font-size: ${({ size }) => size === 'lg' && `2rem`};
+  font-weight: bold;
+`;
+
+const ImgBox = styled.section`
+  display: grid;
+  grid-template-columns: repeat(10, 1fr);
+  grid-template-rows: repeat(6, 1fr);
+  transform-style: preserve-3d;
+  perspective: 10px;
+  perspective-origin: left;
+`;
+
+const imageCellFadeOut = keyframes`
+  0% {
+    transform: scale(1);
+    opacity: 1;
+  }
+  50% {
+    transform: translate3d(10px, 10px, 1px) scale(1.1);
+    border-radius: 2rem;
+    opacity: 0.5;
+  }
+  70% {
+    transform: translate3d(10px, 10px, 0px) scale(1);
+    border-radius: 2rem;
+  }
+  100% {
+    transform: translate3d(0,0,0) scale(0);
+    opacity: 0;
+  }
+`;
+
+const CellLoadingImg = styled.div`
+  min-width: 100%;
+  aspect-ratio: 1/ 1;
+  background: url('./images/FlightLoading.jpg') center/ 1000% no-repeat;
+  background-position: ${({ x, y }) => `${x * 10}% ${y * 17.5}%`};
+
+  animation: ${imageCellFadeOut} forwards 500ms ease-in;
+  animation-delay: ${({ x, y }) => `${(x + y) * 0.2 + 3}s`};
+`;


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [X] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- FlightList페이지에 대해 로딩 페이지 추가 

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1) FlightLoading이라는 항공권 리스트 페이지에 처음으로 들어오는 경우 보여주는 컴포넌트 추가 
 - 따로 페이지를 만들지 않고 항공권 리스트 페이지위에 발생하는 모달 형식으로 제작
 - onAnimationEnd 라는 이벤트를 부여하여 로딩페이지에 대한 애니메이션이 종료시 모달이 사라지고 항공권 리스트 페이지가 바로 나오도록 구현
 - searchparams에서 필요한 key에 대한 값들만 빼서 표시하도록 함.

2) FlightList페이지 수정
 - FlightLoading이라는 컴포넌트는 이 페이지로 처음 넘어왔을 때만 보여야 하기에 그에 따른 조건문 수정
 - 쿼리파라미터로 imgLoading이라는 key를 추가하였고 imgLoading=YES인 경우에만 1)의 컴포넌트가 나타남
 - 이후 imgLoading을 NO로 업데이트하는 fadeOutImgLoading이라는 함수를 만들어 FlightLoading의 props로 넘겨주었음 

3) FlightInfoCard 수정사항 반영
 - FlightTimeInfo라는 컴포넌트로 추가 분리 

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)


<br />

## :: 기타 질문 및 특이 사항

